### PR TITLE
Don't add class to edges in iframe

### DIFF
--- a/src/graph/viewport.ts
+++ b/src/graph/viewport.ts
@@ -101,7 +101,7 @@ export class Viewport {
         $sourceGroup.classList.add('hovered');
         $prevHovered = $sourceGroup;
         let $edge = edgeFrom($sourceGroup.id);
-        $edge && $edge.classList.add('hovered')
+        $edge && $edge.classList.add('hovered');
         $prevHoveredEdge = $edge;
       } else {
         clearSelection();

--- a/src/graph/viewport.ts
+++ b/src/graph/viewport.ts
@@ -101,7 +101,7 @@ export class Viewport {
         $sourceGroup.classList.add('hovered');
         $prevHovered = $sourceGroup;
         let $edge = edgeFrom($sourceGroup.id);
-        $edge.classList.add('hovered');
+        $edge && $edge.classList.add('hovered')
         $prevHoveredEdge = $edge;
       } else {
         clearSelection();


### PR DESCRIPTION
# Motivation

My team and I are making a Gatsby/NetlifyCMS schema editor that uses graphql-voyager as a visualization tool. When editing the schema document, `<GraphQLVoyager/>` component is rendered in a preview pane which runs in an iframe. In this particular setup, mouseover event throws an error because edge source can't be found. 

This breaks the preview mechanism because it bubbles the error to the UI. 

# Approach

This PR adds a check to ensure that $edge is found before calling `classList`.

# Screenshot

## Before

![2019-09-10 16 39 45](https://user-images.githubusercontent.com/74687/64649589-2e5af900-d3eb-11e9-8ab9-1b2642e47cf2.gif)

## After

![2019-09-10 16 42 27](https://user-images.githubusercontent.com/74687/64649574-2733eb00-d3eb-11e9-821d-7c800c93c22d.gif)