### PR TITLE
Show mutations in voyager 

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ module system it is exported as `GraphQLVoyager` global variable.
 - `displayOptions` _(optional)_
   - `displayOptions.skipRelay` [`boolean`, default `true`] - skip relay-related entities
   - `displayOptions.skipDeprecated` [`boolean`, default `true`] - skip deprecated fields and entities that contain only deprecated fields.
-  - `displayOptions.rootType` [`string []`] - name of the type to be used as a root
+  - `displayOptions.rootType` [`string[]`] - name of the type to be used as a root
   - `displayOptions.sortByAlphabet` [`boolean`, default `false`] - sort fields on graph by alphabet
   - `displayOptions.showLeafFields` [`boolean`, default `true`] - show all scalars and enums
   - `displayOptions.hideRoot` [`boolean`, default `false`] - hide the root type

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ module system it is exported as `GraphQLVoyager` global variable.
 - `displayOptions` _(optional)_
   - `displayOptions.skipRelay` [`boolean`, default `true`] - skip relay-related entities
   - `displayOptions.skipDeprecated` [`boolean`, default `true`] - skip deprecated fields and entities that contain only deprecated fields.
-  - `displayOptions.rootType` [`string`] - name of the type to be used as a root
+  - `displayOptions.rootType` [`string array`] - name of the type to be used as a root
   - `displayOptions.sortByAlphabet` [`boolean`, default `false`] - sort fields on graph by alphabet
   - `displayOptions.showLeafFields` [`boolean`, default `true`] - show all scalars and enums
   - `displayOptions.hideRoot` [`boolean`, default `false`] - hide the root type

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ module system it is exported as `GraphQLVoyager` global variable.
 - `displayOptions` _(optional)_
   - `displayOptions.skipRelay` [`boolean`, default `true`] - skip relay-related entities
   - `displayOptions.skipDeprecated` [`boolean`, default `true`] - skip deprecated fields and entities that contain only deprecated fields.
-  - `displayOptions.rootType` [`string array`] - name of the type to be used as a root
+  - `displayOptions.rootType` [`string []`] - name of the type to be used as a root
   - `displayOptions.sortByAlphabet` [`boolean`, default `false`] - sort fields on graph by alphabet
   - `displayOptions.showLeafFields` [`boolean`, default `true`] - show all scalars and enums
   - `displayOptions.hideRoot` [`boolean`, default `false`] - hide the root type

--- a/src/components/Voyager.tsx
+++ b/src/components/Voyager.tsx
@@ -17,10 +17,10 @@ import Settings from './settings/Settings';
 import './Voyager.css';
 import './viewport.css';
 
-type IntrospectionProvider = (query: string) => Promise<any>;
+type IntrospectionProvider = (query: string[]) => Promise<any>;
 
 export interface VoyagerDisplayOptions {
-  rootType?: string;
+  rootType?: string[];
   skipRelay?: boolean;
   skipDeprecated?: boolean;
   showLeafFields?: boolean;

--- a/src/components/settings/RootSelector.tsx
+++ b/src/components/settings/RootSelector.tsx
@@ -8,7 +8,7 @@ import MenuItem from '@material-ui/core/MenuItem';
 import './RootSelector.css';
 
 interface RootSelectorProps {
-  rootType?: string;
+  rootType?: string[];
   schema: any;
   onChange: any;
 }

--- a/src/graph/type-graph.ts
+++ b/src/graph/type-graph.ts
@@ -19,7 +19,7 @@ export function getDefaultRoot(schema) {
   return schema.queryType.name;
 }
 
-export function getTypeGraph(schema, rootType: string, hideRoot: boolean) {
+export function getTypeGraph(schema, rootType: string[], hideRoot: boolean) {
   if (schema === null) return null;
 
   const rootId = typeNameToId(rootType || getDefaultRoot(schema));


### PR DESCRIPTION
Modified the property **displayOptions.rootType** so it takes an array of strings rather than a string by representing the root types. By default, this is ["Query"]. 

This additional functionality allows both Query and Mutation types to be seen on Voyager.

Resolves #37, resolves #200

